### PR TITLE
Move the misplaced line about ZoomWin in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ been removed. You can also stage and revert individual hunks.
 When working with split windows, ZoomWin lets you zoom into a window and
 out again using `Ctrl-W o`
 
+**Customizations**: Janus binds `<leader>zw` to `:ZoomWin`
+
 ## [JSON](https://github.com/elzr/vim-json)
 
 Better JSON and JSONP with distinct highlighting for keywords versus
@@ -371,8 +373,6 @@ quotes concealed (disable with `let g:vim_json_syntax_conceal = 0` in
 `~/.vimrc.after`, folding of {...} and [...] blocks (enable with
 `:setlocal foldmethod=syntax`, and JSON-specific warnings highlighted in
 red.
-
-**Customizations**: Janus binds `<leader>zw` to `:ZoomWin`
 
 ## [BufferGator](https://github.com/jeetsukumaran/vim-buffergator)
 


### PR DESCRIPTION
Pretty minor. Looks like the customization hint about ZoomWin ended up in the JSON section of the README.
